### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "core-js": "^3.1.4",
     "eslint": "^5.16.0",
     "moment": "^2.24.0",
-    "npm": "^6.9.0",
     "pusher": "^2.2.0",
     "react": "^16.8.6",
     "react-bootstrap": "^1.0.0-beta.9",


### PR DESCRIPTION

Hello SoftwareEngineeringLLC!

It seems like you have npm as one of your (dev-) dependency in accessamericatv.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
